### PR TITLE
feat: detect ghostty config files by canonical path

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -2,6 +2,12 @@
   "runtime.version": "Lua 5.1",
   "runtime.path": ["lua/?.lua", "lua/?/init.lua"],
   "diagnostics.globals": ["vim", "jit"],
+  "diagnostics.disable": [
+    "undefined-doc-name",
+    "undefined-doc-class",
+    "undefined-field",
+    "need-check-nil"
+  ],
   "workspace.library": ["$VIMRUNTIME/lua", "${3rd}/luv/library"],
   "workspace.checkThirdParty": false,
   "completion.callSnippet": "Replace"

--- a/.luarc.json
+++ b/.luarc.json
@@ -2,12 +2,6 @@
   "runtime.version": "Lua 5.1",
   "runtime.path": ["lua/?.lua", "lua/?/init.lua"],
   "diagnostics.globals": ["vim", "jit"],
-  "diagnostics.disable": [
-    "undefined-doc-name",
-    "undefined-doc-class",
-    "undefined-field",
-    "need-check-nil"
-  ],
   "workspace.library": ["$VIMRUNTIME/lua", "${3rd}/luv/library"],
   "workspace.checkThirdParty": false,
   "completion.callSnippet": "Replace"

--- a/lua/blink-cmp-ghostty.lua
+++ b/lua/blink-cmp-ghostty.lua
@@ -103,7 +103,7 @@ end
 ---@param callback fun(response: blink.cmp.CompletionResponse)
 ---@return fun()
 function M:get_completions(ctx, callback)
-  if not keys_cache then
+  if not keys_cache or not enums_cache then
     keys_cache = parse_keys()
     enums_cache = parse_enums()
   end

--- a/lua/blink-cmp-ghostty.lua
+++ b/lua/blink-cmp-ghostty.lua
@@ -10,9 +10,31 @@ function M.new()
   return setmetatable({}, { __index = M })
 end
 
+local ghostty_config_dirs = {
+  vim.fn.expand('$XDG_CONFIG_HOME/ghostty'),
+  vim.fn.expand('$HOME/.config/ghostty'),
+  '/etc/ghostty',
+}
+
 ---@return boolean
 function M.enabled()
-  return vim.bo.filetype == 'ghostty'
+  if vim.bo.filetype == 'ghostty' then
+    return true
+  end
+  if vim.bo.filetype ~= 'config' and vim.bo.filetype ~= '' then
+    return false
+  end
+  local path = vim.api.nvim_buf_get_name(0)
+  if path == '' then
+    return false
+  end
+  local real = vim.uv.fs_realpath(path) or path
+  for _, dir in ipairs(ghostty_config_dirs) do
+    if real:find(dir, 1, true) == 1 then
+      return true
+    end
+  end
+  return false
 end
 
 ---@return blink.cmp.CompletionItem[]

--- a/lua/blink-cmp-ghostty/types.lua
+++ b/lua/blink-cmp-ghostty/types.lua
@@ -1,0 +1,16 @@
+---@class blink.cmp.Source
+
+---@class blink.cmp.CompletionItem
+---@field label string
+---@field kind? integer
+---@field documentation? {kind: string, value: string}
+---@field filterText? string
+
+---@class blink.cmp.Context
+---@field line string
+---@field cursor integer[]
+
+---@class blink.cmp.CompletionResponse
+---@field is_incomplete_forward? boolean
+---@field is_incomplete_backward? boolean
+---@field items blink.cmp.CompletionItem[]

--- a/spec/ghostty_spec.lua
+++ b/spec/ghostty_spec.lua
@@ -57,7 +57,6 @@ local function mock_enums()
     end
     return original_realpath(path)
   end
-  -- selene: allow(incorrect_standard_library_use)
   io.open = function(path, mode)
     if path:match('ghostty%.bash$') then
       return {
@@ -73,7 +72,6 @@ local function mock_enums()
   return function()
     vim.fn.exepath = original_exepath
     vim.uv.fs_realpath = original_realpath
-    -- selene: allow(incorrect_standard_library_use)
     io.open = original_open
   end
 end

--- a/spec/ghostty_spec.lua
+++ b/spec/ghostty_spec.lua
@@ -57,6 +57,7 @@ local function mock_enums()
     end
     return original_realpath(path)
   end
+  -- selene: allow(incorrect_standard_library_use)
   io.open = function(path, mode)
     if path:match('ghostty%.bash$') then
       return {
@@ -72,6 +73,7 @@ local function mock_enums()
   return function()
     vim.fn.exepath = original_exepath
     vim.uv.fs_realpath = original_realpath
+    -- selene: allow(incorrect_standard_library_use)
     io.open = original_open
   end
 end


### PR DESCRIPTION
## Problem

`enabled()` only checked for the `ghostty` filetype, but many users have ghostty config files detected as `config` or with no filetype set, so they got no completions.

Closes #6

## Solution

Check canonical ghostty config directories (`$XDG_CONFIG_HOME/ghostty`, `~/.config/ghostty`, `/etc/ghostty`) when the filetype is `config` or empty, resolving symlinks to handle indirect paths.