### PR TITLE
perf: async cache initialization and remove deepcopy

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -2,6 +2,12 @@
   "runtime.version": "Lua 5.1",
   "runtime.path": ["lua/?.lua", "lua/?/init.lua"],
   "diagnostics.globals": ["vim", "jit"],
+  "diagnostics.disable": [
+    "undefined-doc-name",
+    "undefined-doc-class",
+    "undefined-field",
+    "need-check-nil"
+  ],
   "workspace.library": ["$VIMRUNTIME/lua", "${3rd}/luv/library"],
   "workspace.checkThirdParty": false,
   "completion.callSnippet": "Replace"

--- a/.luarc.json
+++ b/.luarc.json
@@ -2,12 +2,6 @@
   "runtime.version": "Lua 5.1",
   "runtime.path": ["lua/?.lua", "lua/?/init.lua"],
   "diagnostics.globals": ["vim", "jit"],
-  "diagnostics.disable": [
-    "undefined-doc-name",
-    "undefined-doc-class",
-    "undefined-field",
-    "need-check-nil"
-  ],
   "workspace.library": ["$VIMRUNTIME/lua", "${3rd}/luv/library"],
   "workspace.checkThirdParty": false,
   "completion.callSnippet": "Replace"

--- a/spec/ghostty_spec.lua
+++ b/spec/ghostty_spec.lua
@@ -19,24 +19,39 @@ local BASH_COMPLETION = table.concat({
 }, '\n')
 
 local function mock_system()
-  local original = vim.system
+  local original_system = vim.system
+  local original_schedule = vim.schedule
   ---@diagnostic disable-next-line: duplicate-set-field
-  vim.system = function(cmd)
+  vim.system = function(cmd, _, on_exit)
     if cmd[1] == 'ghostty' then
+      local result = { stdout = CONFIG_DOCS, code = 0 }
+      if on_exit then
+        on_exit(result)
+        return {}
+      end
       return {
         wait = function()
-          return { stdout = CONFIG_DOCS, code = 0 }
+          return result
         end,
       }
     end
+    local result = { stdout = '', code = 1 }
+    if on_exit then
+      on_exit(result)
+      return {}
+    end
     return {
       wait = function()
-        return { stdout = '', code = 1 }
+        return result
       end,
     }
   end
+  vim.schedule = function(fn)
+    fn()
+  end
   return function()
-    vim.system = original
+    vim.system = original_system
+    vim.schedule = original_schedule
   end
 end
 
@@ -57,6 +72,7 @@ local function mock_enums()
     end
     return original_realpath(path)
   end
+  -- selene: allow(incorrect_standard_library_use)
   io.open = function(path, mode)
     if path:match('ghostty%.bash$') then
       return {
@@ -72,6 +88,7 @@ local function mock_enums()
   return function()
     vim.fn.exepath = original_exepath
     vim.uv.fs_realpath = original_realpath
+    -- selene: allow(incorrect_standard_library_use)
     io.open = original_open
   end
 end

--- a/spec/ghostty_spec.lua
+++ b/spec/ghostty_spec.lua
@@ -72,7 +72,6 @@ local function mock_enums()
     end
     return original_realpath(path)
   end
-  -- selene: allow(incorrect_standard_library_use)
   io.open = function(path, mode)
     if path:match('ghostty%.bash$') then
       return {
@@ -88,7 +87,6 @@ local function mock_enums()
   return function()
     vim.fn.exepath = original_exepath
     vim.uv.fs_realpath = original_realpath
-    -- selene: allow(incorrect_standard_library_use)
     io.open = original_open
   end
 end


### PR DESCRIPTION
## Problem

First completion request blocked the UI with a synchronous `vim.system():wait()` call, and every subsequent key completion unnecessarily deep-copied the entire cache.

Closes #4

## Solution

Use `vim.system` with an async callback to initialize the cache without blocking. Queue pending completion requests during loading and serve them once parsing finishes. Return cached keys directly instead of deep-copying.