### PR TITLE
perf: async enum file read

### DIFF
--- a/lua/blink-cmp-ghostty.lua
+++ b/lua/blink-cmp-ghostty.lua
@@ -193,7 +193,7 @@ function M:get_completions(ctx, callback)
             on_all_done()
             return
           end
-          vim.uv.fs_read(fd, stat.size, 0, function(err3, data)
+          vim.uv.fs_read(fd, stat.size, 0, function(_, data)
             vim.uv.fs_close(fd)
             enums_content = data or ''
             on_all_done()


### PR DESCRIPTION
## Problem

`parse_enums` read the bash-completion file with blocking `io.open`/`fd:read`
on the main thread, stalling the Neovim event loop during completion
initialization.

## Solution

Read the file via `vim.uv.fs_open`/`fs_fstat`/`fs_read` with callbacks, running
in parallel with the `ghostty +show-config --docs` system call using the same
remaining-counter convergence pattern as the other blink-cmp plugins.