### PR TITLE
chore: replace prettier with biome

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       lua: ${{ steps.changes.outputs.lua }}
-      markdown: ${{ steps.changes.outputs.markdown }}
+      biome: ${{ steps.changes.outputs.biome }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -26,8 +26,9 @@ jobs:
               - '.luarc.json'
               - '*.toml'
               - 'vim.yaml'
-            markdown:
-              - '*.md'
+            biome:
+              - '.luarc.json'
+              - 'biome.json'
 
   lua-format:
     name: Lua Format Check
@@ -63,12 +64,12 @@ jobs:
           directories: lua
           configpath: .luarc.json
 
-  markdown-format:
-    name: Markdown Format Check
+  biome-format:
+    name: Biome Format Check
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.markdown == 'true' }}
+    if: ${{ needs.changes.outputs.biome == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run: nix develop --command prettier --check .
+      - run: nix develop --command biome format .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,10 @@ repos:
         files: \.lua$
         pass_filenames: true
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: local
     hooks:
-      - id: prettier
-        name: prettier
-        files: \.(md|toml|yaml|yml|sh)$
+      - id: biome
+        name: biome
+        entry: biome format --write
+        language: system
+        files: \.(json|jsonc)$

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
-  "trailingComma": "none",
-  "semi": false,
-  "singleQuote": true
-}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
                 nlua
               ]
             ))
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.selene
           ];


### PR DESCRIPTION
Replace the remaining Prettier integration with Biome in the dev shell, pre-commit config, and quality workflow.

This adds a minimal Biome config, removes the obsolete Prettier config files, and runs Biome on the repo's supported JSON config files.

Verified with nix develop --command pre-commit run --all-files, stylua --check ., selene --display-style quiet ., biome format ., and busted.